### PR TITLE
Move the descriptions of LocalWaker and Waker and the primary focus.

### DIFF
--- a/text/0000-futures.md
+++ b/text/0000-futures.md
@@ -207,6 +207,11 @@ dispatch mechanism, which consists of an raw object pointer and a virtual functi
 pointer table (vtable). This mechanism allows implementors of an **executor** to
 customize the behavior of `RawWaker`, `Waker` and `LocalWaker` objects.
 
+This mechanism is chosen in favor of trait objects since it allows for more
+flexible memory management schemes. `RawWaker` can be implemented purely in
+terms of global functions and state, on top of reference counted objects, or
+in other ways.
+
 The relation between those `Waker` types is outlined in the following definitions:
 
 ```rust

--- a/text/0000-futures.md
+++ b/text/0000-futures.md
@@ -426,8 +426,8 @@ and the associated vtable manually.
 
 This convience method is based around the `ArcWake` trait. An implementor of
 an executor can define a type which implements the `ArcWake` trait as defined
-below. The `ArcWake` type defines the associated method, which allows to retrieve
-a `LocalWaker` instance from an `Arc` of this type.
+below. The `ArcWake` type defines the associated method `into_local_waker`,
+which allows to retrieve a `LocalWaker` instance from an `Arc` of this type.
 The returned instance will guarantee that the `wake()` and `wake_local` methods
 of the type which implements `ArcWake` are called, whenever `wake()` is called
 on a `Waker` or `LocalWaker`.

--- a/text/0000-futures.md
+++ b/text/0000-futures.md
@@ -106,20 +106,20 @@ like with `Iterator`s. Initially these adapters will be provided entirely "out
 of tree", but eventually they will make their way into the standard library.
 
 Ultimately asynchronous computations are executed in the form of *tasks*,
-which are comparable to lightweight threads. A `task` is a `()`-producing `Future`,
+which are comparable to lightweight threads. A task is a `()`-producing `Future`,
 which is owned by an *executor*, and polled to completion while the being pinned.
 
-*executor*'s provide the ability to "spawn" such `Future`s.
-The implementation of an **executor** schedules the `task` it owns in a cooperative
-fashion. It is up to the implementation of an **executor** whether on or more
-operation system threads are used for this, as well as how many `task`s can be
+*executor*s provide the ability to "spawn" such `Future`s.
+The implementation of an executor schedules the task it owns in a cooperative
+fashion. It is up to the implementation of an executor whether on or more
+operation system threads are used for this, as well as how many tasks can be
 spawned on them in parallel.
 
 This RFC does not include any definition of an executor. It merely defines the
-interaction between **executor**s, `task`s and `Future`s, in the form of APIs
-that allow `task`s to request getting scheduled again.
+interaction between executors, tasks and `Future`s, in the form of APIs
+that allow tasks to request getting scheduled again.
 The `task` module provides these APIs, which are required when manually implementing
-`Future`s or **executors**.
+`Future`s or executors.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -171,17 +171,17 @@ This functionality is provided through a set of `Waker` types.
 `Waker`s are objects which are passed as a parameter to the `Future::poll` call,
 and which can be stored by the implementation of those `Futures`s. Whenever a
 `Future` has the need to get polled again, it can use the `wake` method of the
-waker in order to inform the executor that the `task` which owns the `Future`
+waker in order to inform the executor that the task which owns the `Future`
 should get scheduled and executed again.
 
-The RFC defines 2 concrete `Waker` types, with which implementors of `Futures`
+The RFC defines two concrete `Waker` types, with which implementors of `Futures`
 and asynchronous functions will interact: `Waker` and `LocalWaker`. Both of
-these types define a `wake(&self)` function which is used to schedule the `task`
+these types define a `wake(&self)` function which is used to schedule the task
 that is associated to the `Waker` again.
 
 The difference between those types is that `Waker` implements the `Send` and `Sync`
 marker traits, while `LocalWaker` doesn't. This means a `Waker` can be sent to
-another thread and stored there in order to wake up the associated `task` later on,
+another thread and stored there in order to wake up the associated task later on,
 while a `LocalWaker` can't be sent. Depending on the capabilities of the underlying
 executor a `LocalWaker` can be converted into a `Waker`. Most executors in the
 ecosystem will implement this functionality. The exception will be highly
@@ -190,21 +190,21 @@ specialized executors, which e.g. want to avoid the cost of all synchronization.
 Calling the `wake()` method on a `Waker` will in general be more expensive than
 on a `LocalWaker` instance, due to additional synchronization.
 
-Executors will always pass a `LocalWaker` instance to the `task`s they poll.
+Executors will always pass a `LocalWaker` instance to the tasks they poll.
 
-The mechanism through which `task`s get scheduled again depends on the **executor**
-which is driving the `task`.
+The mechanism through which tasks get scheduled again depends on the executor
+which is driving the task.
 Possible ways of waking up a an executor include:
-- If the **executor** is blocked on a condition variable, the condition variable
+- If the executor is blocked on a condition variable, the condition variable
   needs to get notified.
-- If the **executor** is blocked on a system call like `select`, it might need
+- If the executor is blocked on a system call like `select`, it might need
   to get woken up by a syscall like `write` to a pipe.
-- If the **executor**'s thread is parked, the wakeup call needs to unpark it.
+- If the executor's thread is parked, the wakeup call needs to unpark it.
 
 In order to accomodate for this behavior, the `Waker` and `LocalWaker` types are
 defined through a `RawWaker` type, which is an struct that defines a dynamic
 dispatch mechanism, which consists of an raw object pointer and a virtual function
-pointer table (vtable). This mechanism allows implementors of an **executor** to
+pointer table (vtable). This mechanism allows implementors of an executor to
 customize the behavior of `RawWaker`, `Waker` and `LocalWaker` objects.
 
 This mechanism is chosen in favor of trait objects since it allows for more
@@ -256,10 +256,10 @@ pub struct RawWakerVTable {
     /// data, changing the reference count would not be necessary.
     ///
     /// If a conversion is not supported, the implementation should return
-    /// `INVALID_RAW_WAKER`. In this case the implementation must still make
+    /// `None`. In this case the implementation must still make
     /// sure that the data pointer which is passed to the function is correctly
     /// released, e.g. by calling the associated `drop_fn` on it.
-    pub into_waker: unsafe fn(*const ()) -> RawWaker,
+    pub into_waker: unsafe fn(*const ()) -> Option<RawWaker>,
     /// This function will be called when `wake` is called on the `RawWaker`.
     pub wake: unsafe fn(*const ()),
     /// This function gets called when a `RawWaker` gets dropped.
@@ -268,18 +268,6 @@ pub struct RawWakerVTable {
     /// associated task.
     pub drop_fn: unsafe fn(*const ()),
 }
-
-/// A guard object that can be returned by `into_waker` if the implementation
-/// wants to signal that a conversion isn't possible.
-pub const INVALID_RAW_WAKER: RawWaker = RawWaker {
-    data: core::ptr::null(),
-    vtable: &RawWakerVTable {
-        clone: invalid_fn_call, // Those panic when called
-        into_waker: invalid_fn_call,
-        wake: invalid_fn_call,
-        drop_fn: invalid_fn_call,
-    },
-};
 
 /// A `Waker` is a handle for waking up a task by notifying its executor that it
 /// is ready to be run.
@@ -383,14 +371,15 @@ impl LocalWaker {
     /// getting woken up from a different thread.
     pub fn try_into_waker(self) -> Option<Waker> {
         unsafe {
-            let raw_waker = (self.waker.vtable.into_waker)(self.waker.data);
+            let maybe_raw_waker = (self.waker.vtable.into_waker)(self.waker.data);
             // Avoid that the drop runs on self, which would e.g. decrease
-            // the refcount on it.
+            // the refcount on it. The object has been consumed or converted
+            // by the `into_waker` function.
             mem::forget(self);
-            if raw_waker == INVALID_RAW_WAKER {
-                return None;
+            match maybe_raw_waker {
+                Some(rw) => Some(Waker::new_unchecked(rw)),
+                None => None,
             }
-            Some(Waker::new_unchecked(raw_waker))
         }
     }
 
@@ -417,14 +406,12 @@ impl LocalWaker {
 }
 
 // The implementations of `Clone` and `Drop` follow what is shown in for `Waker`.
-
-// TODO: Should `Waker` still implement `From<LocalWaker>` or potentially `TryFrom`?
 ```
 
 `Waker`s must fulfill the following requirements:
 - They must be cloneable
-- If all instances of a `Waker` have been dropped and their associated `task` had
-  been driven to completion, all resources which had been allocated for the `task`
+- If all instances of a `Waker` have been dropped and their associated task had
+  been driven to completion, all resources which had been allocated for the task
   must have been released.
 - It must be safe to call `wake()` on a `Waker` even if the associated task has
   already been driven to completion.
@@ -469,9 +456,12 @@ pub trait ArcWake: Send + Sync {
     /// This function is like wake, but will only be called from the thread on which this
     /// `ArcWake` was created.
     ///
+    /// This function is marked unsafe because callers must guarantee that
+    /// they call it only on the task on which the `ArcWake` had been created.
+    ///
     /// Executors generally maintain a queue of "ready" tasks; `wake_local` should place
     /// the associated task onto this queue.
-    fn wake_local(self: &Arc<Self>);
+    unsafe fn wake_local(self: &Arc<Self>);
 
     /// Creates a `LocalWaker` from an Arc<T>, if T implements ArcWake.
     ///
@@ -509,9 +499,9 @@ impl ArcWake for Task {
 ```
 
 The use of `&Arc<Self>` rather than just `&self` makes it possible to work directly with
-the trait object for `Wake`, including cloning it.
+the `Arc` that contains the object which implements `ArcWake`. This enables
+use-cases like cloning it.
 
-It's possible to construct a `Waker` using `From<Arc<dyn Wake>>`. // TODO: Is that really the case or only `impl Wake`?
 
 ## `core::future` module
 

--- a/text/0000-futures.md
+++ b/text/0000-futures.md
@@ -242,7 +242,7 @@ pub struct RawWakerVTable {
     /// The implementation of this function must retain all resources that are
     /// required for this additional instance of a `RawWaker` and associated
     /// task.
-    pub clone: unsafe fn(*const ()) -> *const (),
+    pub clone: unsafe fn(*const ()) -> RawWaker,
     /// This function will be called when a `LocalWaker` should be converted into
     /// a thread-safe `Waker`. The implementation of this function must return
     /// a new `RawWaker` which can fulfill the requirements of `Waker`. It can

--- a/text/0000-futures.md
+++ b/text/0000-futures.md
@@ -453,7 +453,7 @@ pub trait ArcWake: Send + Sync {
     ///
     /// Executors generally maintain a queue of "ready" tasks; `wake` should place
     /// the associated task onto this queue.
-    fn wake(self: &Arc<Self>);
+    fn wake(arc_self: &Arc<Self>);
 
     /// Indicates that the associated task is ready to make progress and should be polled.
     /// This function is like `wake`, but will only be called from the thread on which this
@@ -464,7 +464,9 @@ pub trait ArcWake: Send + Sync {
     ///
     /// Executors generally maintain a queue of "ready" tasks; `wake_local` should place
     /// the associated task onto this queue.
-    unsafe fn wake_local(self: &Arc<Self>);
+    unsafe fn wake_local(arc_self: &Arc<Self>) {
+        Self::wake(arc_self);
+    }
 
     /// Creates a `LocalWaker` from an Arc<T>, if T implements ArcWake.
     ///
@@ -565,7 +567,7 @@ pub trait Future {
     /// # [`LocalWaker`], [`Waker`] and thread-safety
     ///
     /// The `poll` function takes a [`LocalWaker`], an object which knows how to
-     /// awaken the current task. [`LocalWaker`] is not `Send` nor `Sync`, so
+    /// awaken the current task. [`LocalWaker`] is not `Send` nor `Sync`, so
     /// to make thread-safe futures the [`LocalWaker::into_waker`] and
     /// [`LocalWaker::try_into_waker`] methods should be used to convert
     /// the [`LocalWaker`] into a thread-safe version.

--- a/text/0000-futures.md
+++ b/text/0000-futures.md
@@ -242,9 +242,13 @@ pub struct RawWaker {
 pub struct RawWakerVTable {
     /// This function will be called when the `RawWaker` gets cloned, e.g. when
     /// the `Waker` or `LocalWaker` in which the `RawWaker` is stored gets cloned.
+    ///
     /// The implementation of this function must retain all resources that are
     /// required for this additional instance of a `RawWaker` and associated
-    /// task.
+    /// task. The implementation must return a valid `RawWaker` that behaves
+    /// equivalent to the `RawWaker` that got cloned. E.g. cloning a `RawWaker`
+    /// that implemented a thread-safe wakeup for use in `Waker` must return
+    /// a `RawWaker` that implements the same wakeup behavior.
     pub clone: unsafe fn(*const ()) -> RawWaker,
     /// This function will be called when a `LocalWaker` should be converted into
     /// a thread-safe `Waker`. The implementation of this function must return
@@ -266,6 +270,7 @@ pub struct RawWakerVTable {
     /// This function will be called when `wake` is called on the `RawWaker`.
     pub wake: unsafe fn(*const ()),
     /// This function gets called when a `RawWaker` gets dropped.
+    ///
     /// The implementation of this function must make sure to release any
     /// resources that are associated with this instance of a `RawWaker` and
     /// associated task.
@@ -421,8 +426,8 @@ impl LocalWaker {
 - `Waker::wake()` must wake up an executor even if it is called from an arbitrary
   thread.
 
-An executor which implements `RawWaker` must therefore make sure that all these
-requirements are fulfilled.
+An executor that instantiates a `RawWaker` must therefore make sure that all
+these requirements are fulfilled.
 
 Since many of the ownership semantics that are required here can easily be met
 through a reference-counted `Waker` implementation, a convienence method for


### PR DESCRIPTION
I started with adding more information around the `LocalWaker` and `Waker` structs. I kept the old names since most implementations of `Futures` at the end will store the thread safe wakers, and `Waker` sounded more natural than `SendWaker` for this.

There are two changes on API surface level compared to the current implementation:
- There is no more implicit `impl From<LocalWaker> for Waker` anymore. The reasoning was that some singlethreaded `LocalWaker`s can not be converted into `Waker`s and trying to convert them leads to a panic. That seems ok an explicit method call, but not on an implicit conversion.
- I removed the `will_wake_nonlocal/local` functions, which would need to compare two `RawWaker`s that are potentially different. I think just comparing the data pointer won't work here. Comparing data pointer and vtable exactly would work, but might not hit lots of `true`s on executors which change the vtable. We could add another method the vtable. Or leave things out. Is there currently a use-case for these methods?

I want to revisit the `Wake` section and rename things to `ArcWake`. This can then be a part of the RFC which can get either stabilized or not (the conversion can also live next to executor implementations). However I haven't gotten to this yet, and wanted to ask for feedback for the first parts in the meantime.